### PR TITLE
Safe tx resubmit

### DIFF
--- a/controllers/login.controller.es6
+++ b/controllers/login.controller.es6
@@ -1,6 +1,6 @@
 import {Intent} from "interstellar-core";
 import {Controller, Inject} from "interstellar-core";
-import {Keypair} from 'stellar-base';
+import {Keypair} from 'stellar-sdk';
 import {Alert, AlertGroup} from 'interstellar-ui-messages';
 import StellarLedger from 'stellar-ledger-api';
 

--- a/templates/send-widget.template.html
+++ b/templates/send-widget.template.html
@@ -126,9 +126,17 @@
     <div ng-if="!widget.success">
       <p class="sendOutcome__label">Transaction failed</p>
 
-      <pre class="sendOutcome__code"><code>{{widget.outcomeMessage}}</code></pre>
+      <p class="" ng-if="widget.needsResubmit">
+        <strong>Warning</strong> We submitted your transaction to the network but because of the network conditions we are
+        not certain about it's status: it could either succeed or fail. Instead of recreating the transaction you should use
+        the button below to safely resubmit the transaction:<br />
+        <br />
+        <button class="s-button sendConfirm__submit" ng-click="widget.resubmitTransaction()">Resubmit transaction</button>
+      </p>
+
+      <pre class="sendOutcome__code" ng-if="widget.outcomeMessage"><code>{{widget.outcomeMessage}}</code></pre>
     </div>
 
-    <button class="s-button sendOutcome__return" ng-click="widget.showView($event, 'sendSetup')">Send another transaction</button>
+    <button class="s-button sendOutcome__return" ng-if="widget.success || !widget.needsResubmit" ng-click="widget.showView($event, 'sendSetup')">Send another transaction</button>
   </div>
 </div>


### PR DESCRIPTION
This PR introduces a safe tx resubmit function that can be executed when Account Viewer is not sure if tx has been submitted successfully or not (ex. connection timeouts).

It will display the following message in such cases:
![screen shot 2017-12-14 at 18 58 31](https://user-images.githubusercontent.com/464938/34007082-dbc0e5ee-e100-11e7-9213-80bc73d1adeb.png)

Please note that we display: "Send another transaction" link if we get a response body from horizon. We hide this link in this view to disallow users to create another transaction.

Because of the fact that a lot of code has been moved I recommend reviewing this PR in the split view mode.