### PR TITLE
Display message saying that your private key won't be displayed again.

### DIFF
--- a/styles/_loginBox.scss
+++ b/styles/_loginBox.scss
@@ -1,5 +1,5 @@
 .loginBox {
-  max-width: 30em;
+  max-width: 40em;
   padding: 1.5em 2em 2em 2em;
   border: 1px solid $s-color-primary7;
   border-bottom: 0;
@@ -43,4 +43,7 @@
     padding-left: 5em;
     padding-right: 5em;
   }
+}
+.loginBox__warning {
+  color: $s-color-alert;
 }

--- a/styles/_welcomeBox.scss
+++ b/styles/_welcomeBox.scss
@@ -1,5 +1,5 @@
 .welcomeBox {
-  max-width: 30em;
+  max-width: 40em;
   padding: 1.5em 2em 1em 2em;
   border: 1px solid $s-color-primary7;
   border-bottom: 0;
@@ -16,7 +16,7 @@
 }
 
 .middleBox {
-  max-width: 30em;
+  max-width: 40em;
   padding: 1.5em 2em 1em 2em;
   border-top: 1px solid $s-color-primary7;
   border-left: 1px solid $s-color-primary7;
@@ -33,7 +33,7 @@
 }
 
 .legacyBox {
-  max-width: 30em;
+  max-width: 40em;
   padding: 1.5em 2em 1em 2em;
   border: 1px solid $s-color-primary7;
   background: $s-color-primary9;

--- a/templates/login.template.html
+++ b/templates/login.template.html
@@ -37,8 +37,8 @@
         <div ng-if="login.newKeypair">
           <p class="loginBox__warning">
             <strong>ATTENTION:</strong>
-            Please write down your secret key and keep it safe.
-            It won't be displayed again.
+            Please write down your secret key and keep it safe. It won't be displayed again.
+            You will lose access to your lumens if you lose your secret key.
           </p>
 
           <div class="keypair">

--- a/templates/login.template.html
+++ b/templates/login.template.html
@@ -30,13 +30,26 @@
       <button type="submit" class="s-button loginBox__submit" ng-class="{'is-disabled': login.processing}" ng-disabled="login.processing">Sign in</button>
     </form>
     <div class="middleBox">
-        Generate key pair for a new account
-        <div class="keypair" ng-if="login.newKeypair">
-        Public Key:<br />
-        <code>{{login.newKeypair.publicKey}}</code><br />
-        Secret Key:<br />
-        <code>{{login.newKeypair.secretKey}}</code>
+        <p>
+          Generate key pair for a new account
+        </p>
+
+        <div ng-if="login.newKeypair">
+          <p class="loginBox__warning">
+            <strong>ATTENTION:</strong>
+            Please write down your secret key and keep it safe.
+            It won't be displayed again.
+          </p>
+
+          <div class="keypair">
+            Public Key:<br />
+            <code>{{login.newKeypair.publicKey}}</code><br /><br />
+
+            Secret Key:<br />
+            <code>{{login.newKeypair.secretKey}}</code>
+          </div>
         </div>
+
         <button type="button" class="s-button loginBox__submit" ng-click="login.generate()">Generate</button>
     </div>
     <div class="middleBox">


### PR DESCRIPTION
This closes #53.

This helps preventing cases like https://www.reddit.com/r/Stellar/comments/7t3xp8/psa_on_the_importance_of_your_private_key_and_my/.

This change also increases the width, so the private it's visible in its whole, in case anyone wants to type the private key, or write it down by hand.

![animation](https://user-images.githubusercontent.com/3009/35459907-e2235324-0296-11e8-8606-70966e97ce9e.gif)
