### PR TITLE
Improve "Account doesn't exits on the network" message

### DIFF
--- a/templates/balance-widget.template.html
+++ b/templates/balance-widget.template.html
@@ -17,7 +17,7 @@
     <div class="so-chunk">
       <div class="accountUnfunded">
         <div class="s-alert s-alert--warning accountUnfunded__alert">
-          This account doesn't exist on the network. To create this account, send it at least 1 lumen (XLM) to fulfill the <a href="https://www.stellar.org/developers/learn/concepts/fees.html#minimum-balance" target="_blank">minimum balance</a>.
+          This account is currently inactive. To activate it, <a href="https://www.stellar.org/developers/learn/concepts/fees.html#minimum-balance" target="_blank">send at least 1 lumen (XLM)</a> to the Stellar public key displayed above.
         </div>
       </div>
     </div>


### PR DESCRIPTION
It may be unclear to users what it means for an account to *not exist on the network* and how sending 1 XLM to this account *creates it*.

Here I improve this message from:

> This account doesn't exist on the network. To create this account, send it at least 1 lumen (XLM) to fulfill the minimum balance.


to:

> This account is currently inactive. To activate it, send at least 1 lumen (XLM) to the Stellar public key displayed above.
