### PR TITLE
Increase threshold for showing payments by default

### DIFF
--- a/controllers/history-widget.controller.es6
+++ b/controllers/history-widget.controller.es6
@@ -26,15 +26,23 @@ export default class HistoryWidgetController {
   }
 
   visiblePayments() {
-    if (!this.hideSmallAmounts) {
+    if (this.hideSmallAmounts) {
+      return this.filteredPayments();
+    } else {
       return this.payments;
     }
+  }
 
+  filteredPayments() {
     return this.payments.filter(payment => Number(payment.amount) >= MINIMUM_AMOUNT_TO_DISPLAY);
   }
 
   toggleDisplaySmallAmounts() {
     this.hideSmallAmounts = !this.hideSmallAmounts;
+  }
+
+  showSmallAmountsToggle() {
+    return this.filteredPayments().length !== this.payments.length;
   }
 
   loadPayments() {

--- a/controllers/history-widget.controller.es6
+++ b/controllers/history-widget.controller.es6
@@ -2,8 +2,6 @@ import {Widget, Inject} from 'interstellar-core';
 import BigNumber from 'bignumber.js';
 import _ from 'lodash';
 
-const MINIMUM_AMOUNT_TO_DISPLAY = 0.5
-
 @Widget('history', 'HistoryWidgetController', 'interstellar-basic-client/history-widget')
 @Inject("$scope", "interstellar-sessions.Sessions", "interstellar-network.Server")
 export default class HistoryWidgetController {
@@ -20,6 +18,7 @@ export default class HistoryWidgetController {
     this.payments = [];
     this.loading = true;
     this.showLengthLimitAlert = false;
+    this.minimumAmountToDisplay = 0.5;
     this.hideSmallAmounts = true;
 
     this.loadPayments();
@@ -34,7 +33,7 @@ export default class HistoryWidgetController {
   }
 
   filteredPayments() {
-    return this.payments.filter(payment => Number(payment.amount) >= MINIMUM_AMOUNT_TO_DISPLAY);
+    return this.payments.filter(payment => Number(payment.amount) >= this.minimumAmountToDisplay);
   }
 
   toggleDisplaySmallAmounts() {

--- a/controllers/history-widget.controller.es6
+++ b/controllers/history-widget.controller.es6
@@ -2,7 +2,7 @@ import {Widget, Inject} from 'interstellar-core';
 import BigNumber from 'bignumber.js';
 import _ from 'lodash';
 
-const MINIMUM_AMOUNT_TO_DISPLAY = 0.01
+const MINIMUM_AMOUNT_TO_DISPLAY = 0.5
 
 @Widget('history', 'HistoryWidgetController', 'interstellar-basic-client/history-widget')
 @Inject("$scope", "interstellar-sessions.Sessions", "interstellar-network.Server")

--- a/controllers/history-widget.controller.es6
+++ b/controllers/history-widget.controller.es6
@@ -52,7 +52,7 @@ export default class HistoryWidgetController {
           this.showLengthLimitAlert = true;
         }
 
-        this.setupSteaming();
+        this.setupStreaming();
       })
       .catch(e => {
         if (e.name === 'NotFoundError') {
@@ -69,7 +69,7 @@ export default class HistoryWidgetController {
       });
   }
 
-  setupSteaming() {
+  setupStreaming() {
     // Setup event stream
     let cursor;
     if (this.payments.length > 0) {

--- a/styles/_history.scss
+++ b/styles/_history.scss
@@ -4,7 +4,7 @@
   border-top: 1px solid $s-color-neutral7;
 }
   .history__title {
-    margin-bottom: 1em;
+    margin-bottom: .5em;
   }
   .history__table {
     overflow: auto;

--- a/templates/history-widget.template.html
+++ b/templates/history-widget.template.html
@@ -9,15 +9,15 @@
     <div ng-if="widget.showSmallAmountsToggle()">
       <p ng-if="widget.hideSmallAmounts">
         <small>
-          This tool is hiding payments smaller than 0.5 XLM.
-          <button ng-click="widget.toggleDisplaySmallAmounts()">View All</button>
+          This tool is hiding payments smaller than 0.5 XLM. <br />
+          <button ng-click="widget.toggleDisplaySmallAmounts()" class="s-button s-button__light">View all payments</button>
         </small>
       </p>
 
       <p ng-if="!widget.hideSmallAmounts">
         <small>
-          This tool is showing payments smaller than 0.5 XLM.
-          <button ng-click="widget.toggleDisplaySmallAmounts()">Hide them instead</button>
+          This tool is showing all payments, including payments smaller than 0.5 XLM. <br />
+          <button ng-click="widget.toggleDisplaySmallAmounts()" class="s-button s-button__light">Hide small payments</button>
         </small>
       </p>
     </div>

--- a/templates/history-widget.template.html
+++ b/templates/history-widget.template.html
@@ -6,19 +6,21 @@
   </p>
 
   <div class="history__table" ng-if="widget.payments.length > 0">
-    <p ng-if="widget.hideSmallAmounts">
-      <small>
-        This tool is hiding payments smaller than 0.5 XLM.
-        <button ng-click="widget.toggleDisplaySmallAmounts()">View All</button>
-      </small>
-    </p>
+    <div ng-if="widget.showSmallAmountsToggle()">
+      <p ng-if="widget.hideSmallAmounts">
+        <small>
+          This tool is hiding payments smaller than 0.5 XLM.
+          <button ng-click="widget.toggleDisplaySmallAmounts()">View All</button>
+        </small>
+      </p>
 
-    <p ng-if="!widget.hideSmallAmounts">
-      <small>
-        This tool is showing payments smaller than 0.5 XLM.
-        <button ng-click="widget.toggleDisplaySmallAmounts()">Hide them instead</button>
-      </small>
-    </p>
+      <p ng-if="!widget.hideSmallAmounts">
+        <small>
+          This tool is showing payments smaller than 0.5 XLM.
+          <button ng-click="widget.toggleDisplaySmallAmounts()">Hide them instead</button>
+        </small>
+      </p>
+    </div>
 
     <table class="historyTable">
       <tr class="historyTable__row historyTable__row--header">

--- a/templates/history-widget.template.html
+++ b/templates/history-widget.template.html
@@ -8,14 +8,14 @@
   <div class="history__table" ng-if="widget.payments.length > 0">
     <p ng-if="widget.hideSmallAmounts">
       <small>
-        This tool is hiding payments smaller than 0.01 XLM.
+        This tool is hiding payments smaller than 0.5 XLM.
         <button ng-click="widget.toggleDisplaySmallAmounts()">View All</button>
       </small>
     </p>
 
     <p ng-if="!widget.hideSmallAmounts">
       <small>
-        This tool is showing payments smaller than 0.01 XLM.
+        This tool is showing payments smaller than 0.5 XLM.
         <button ng-click="widget.toggleDisplaySmallAmounts()">Hide them instead</button>
       </small>
     </p>

--- a/templates/history-widget.template.html
+++ b/templates/history-widget.template.html
@@ -9,14 +9,14 @@
     <div ng-if="widget.showSmallAmountsToggle()">
       <p ng-if="widget.hideSmallAmounts">
         <small>
-          This tool is hiding payments smaller than 0.5 XLM. <br />
+          This tool is hiding payments smaller than {{widget.minimumAmountToDisplay}} XLM. <br />
           <button ng-click="widget.toggleDisplaySmallAmounts()" class="s-button s-button__light">View all payments</button>
         </small>
       </p>
 
       <p ng-if="!widget.hideSmallAmounts">
         <small>
-          This tool is showing all payments, including payments smaller than 0.5 XLM. <br />
+          This tool is showing all payments, including payments smaller than {{widget.minimumAmountToDisplay}} XLM. <br />
           <button ng-click="widget.toggleDisplaySmallAmounts()" class="s-button s-button__light">Hide small payments</button>
         </small>
       </p>


### PR DESCRIPTION
This PR proposes to increase the threshold for transactions to be shown in the account viewer by default to **0.5 XLM (~ USD 0.20)**. The previous limit of 0.01 XLM (~ USD 0.004) does not seem to deter spammers and scammers (see screenshots of spam transactions made since the hiding small amounts feature had been introduced in the account viewer).

**Recent transactions with spam/scam intentions**

![image](https://user-images.githubusercontent.com/1100176/39083897-b2017392-456c-11e8-803f-a2ef3dde94bb.png)

![image](https://user-images.githubusercontent.com/1100176/39083886-7dd4e248-456c-11e8-973b-b38f7f22e308.png)

**UX improvement**

Previously the message that payments smaller than the threshold are hidden was always shown, regardless of if any transaction had actually been hidden for this account. With this PR the message and toggle to show all payments/hide small payments is only rendered if any payments have been hidden, so that users don't get confused when clicking this button and nothing changes in the transaction history.

**Wording changes**

_When hiding small payments_
![image](https://user-images.githubusercontent.com/1100176/39083988-53a6c11a-456e-11e8-8b3b-7bdffe3d4e16.png)

_When showing all payments_
![image](https://user-images.githubusercontent.com/1100176/39084018-b49b242a-456e-11e8-873c-c3a9da58734e.png)

