### PR TITLE
Remove outdated link to more advanced wallets

### DIFF
--- a/templates/login.template.html
+++ b/templates/login.template.html
@@ -79,7 +79,3 @@
     </div>
   </div>
 </div>
-
-<div style="margin-top: 20px; font-size: 14px; text-align: center;">
-  <a href="https://www.stellar.org/about/directory#wallets">Try other more advanced Wallets</a>
-</div>


### PR DESCRIPTION
Removing link since the list of wallets is already linked on the login page, and the link is outdated.

_Login Screen_
![removed-link](https://user-images.githubusercontent.com/1100176/39084193-957ade7a-4571-11e8-8fd4-be8ed631cd71.png)

