### PR TITLE
Add Binance to known accounts

### DIFF
--- a/known_accounts.es6
+++ b/known_accounts.es6
@@ -22,6 +22,10 @@ const knownAccounts = {
   'GC4KAS6W2YCGJGLP633A6F6AKTCV4WSLMTMIQRSEQE5QRRVKSX7THV6S': {
     name: 'BitcoinIndonesia',
     requiredMemoType: 'MEMO_TEXT'
+  },
+  'GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A': {
+    name: 'Binance',
+    requiredMemoType: 'MEMO_ID'
   }
 };
 export default knownAccounts;


### PR DESCRIPTION
Binance requires a memo for crediting the right user account with the received XLM, like other exchanges.