### PR TITLE
Allow multisig accounts to view signed transaction XDR instead of submitting

### DIFF
--- a/styles/_additionalSigners.scss
+++ b/styles/_additionalSigners.scss
@@ -1,0 +1,17 @@
+.additionalSigners {
+}
+  .additionalSigners__label {
+    text-align: center;
+    font-size: $s-scale-3;
+  }
+  .additionalSigners__xdr {
+    background: $s-color-neutral8;
+    padding: 1em;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
+  .additionalSigners__return {
+    display: block;
+    margin: 0 auto;
+  }

--- a/styles/main.header.scss
+++ b/styles/main.header.scss
@@ -20,6 +20,7 @@
 @import "sendPane";
 @import "sendSetup";
 @import "sendWaiting";
+@import "additionalSigners";
 
 @import "history";
 @import "historyTable";

--- a/templates/send-widget.template.html
+++ b/templates/send-widget.template.html
@@ -150,4 +150,16 @@
 
     <button class="s-button sendOutcome__return" ng-if="widget.success || !widget.needsResubmit" ng-click="widget.showView($event, 'sendSetup')">Send another transaction</button>
   </div>
+
+  <div class="additionalSigners" ng-if="widget.view === 'additionalSigners'">
+    <p class="additionalSigners__label">Requires more signatures</p>
+    
+    <p>This transaction requires additional signatures before it can be submitted.</p>
+    <p>Copy the transaction XDR below and add the required signatures before submitting it to the network.</p>
+    
+    <pre class="additionalSigners__xdr"><code>{{widget.lastTransactionXDR}}</code></pre>
+    
+    <button class="s-button additionalSigners__return" ng-click="widget.showView($event, 'sendSetup')">Send another transaction</button>
+  </div>
+
 </div>


### PR DESCRIPTION
This will let accounts that use multisig to copy the transaction XDR so they can submit it to their multisig coordinator of choice.

![Additional Signers Message](https://user-images.githubusercontent.com/709282/39345589-51d3f16c-49b7-11e8-9d59-fa77ed1a17f4.png)
