### PR TITLE
Allow enough space so full public key fits in the "To" input

### DIFF
--- a/styles/main.header.scss
+++ b/styles/main.header.scss
@@ -27,7 +27,7 @@
 
 
 .sendSetup, .sendConfirm, .sendWaiting, .sendOutcome {
-  max-width: 36em;
+  max-width: 37em;
   margin: 0 auto 3em 0;
 }
 .sendConfirm, .sendWaiting, .sendOutcome {


### PR DESCRIPTION
Super small quality-of-life change that I noticed when I was taking screenshots for a tutorial.

Before:
![screen shot 2018-04-29 at 12 31 32 am](https://user-images.githubusercontent.com/709282/39403279-7b878da4-4b45-11e8-9fe2-908550163724.png)

After:
![screen shot 2018-04-29 at 12 33 33 am](https://user-images.githubusercontent.com/709282/39403281-83f4ef68-4b45-11e8-8807-be0d07c4d82f.png)
