### PR TITLE
Fix balance rendering when using ledgers

### DIFF
--- a/controllers/balance-widget.controller.es6
+++ b/controllers/balance-widget.controller.es6
@@ -122,7 +122,7 @@ export default class BalanceWidgetController {
     } else {
       balance = 0;
     }
-    this.balance = new BigNumber(balance).toFormat();
+    this.balance = new BigNumber(balance).toNumber();
     this.balanceLoaded = true;
     this.$scope.$apply();
   }


### PR DESCRIPTION
We were formatting the string twice, once in [the balance widget controller](https://github.com/stellar/account-viewer/blob/65c669484e105c59370747bcc194621812e15823/controllers/balance-widget.controller.es6#L125) and again in [the template](https://github.com/stellar/account-viewer/blob/65c669484e105c59370747bcc194621812e15823/templates/balance-widget.template.html#L5). I suspect that the comma thousands separator breaks the template formatting logic, changing it to do a simple string format fixes the issue.

Fixes #104 