### PR TITLE
Set ledger exchange timeout to 1 minute

### DIFF
--- a/controllers/send-widget.controller.es6
+++ b/controllers/send-widget.controller.es6
@@ -485,7 +485,9 @@ export default class SendWidgetController {
 
         if (this.useLedger) {
           const openTimeout = 60 * 1000; // one minute
+          const exchangeTimeout = 60 * 1000
           return LedgerTransport.create(openTimeout).then((transport) => {
+            transport.setExchangeTimeout(exchangeTimeout)
             const ledgerApi = new LedgerStr(transport);
             return ledgerApi.signTransaction(this.bip32Path, transaction.signatureBase()).then(result => {
               let signature = result['signature'];


### PR DESCRIPTION
This is a marginal improvement over the current state, but still extremely broken. In local testing, I'm consistently able to sign transactions _iff_ I wait > 30s before advancing from the `Review Transaction` screen. I'm no longer getting `Unhandled rejection` errors in the console, however, so the problem appears to be with the Ledger device.