### PR TITLE
Fix images on Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.tmp
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN apt-get update && apt-get install -y curl git make build-essential && \
 
 FROM nginx:1.17
 
-COPY --from=build /app/src/.tmp/webpacked/* /usr/share/nginx/html/
+COPY --from=build /app/src/.tmp/webpacked /usr/share/nginx/html/


### PR DESCRIPTION
It turns out `COPY dir/* /to/place` nukes subdirectory structure and only keeps the raw files!