### PR TITLE
Update SDK to latest, support SEP-29

### DIFF
--- a/controllers/send-widget.controller.es6
+++ b/controllers/send-widget.controller.es6
@@ -30,8 +30,6 @@ export default class SendWidgetController {
       return;
     }
 
-    Network.use(new Network(Config.get('modules.interstellar-network.networkPassphrase')));
-
     this.view = 'sendSetup';
     this.$scope = $scope;
     this.$rootScope = $rootScope;
@@ -444,8 +442,11 @@ export default class SendWidgetController {
 
     var transaction = new Transaction(this.lastTransactionXDR);
 
-    return this.Server.submitTransaction(transaction)
-      .then(this._submitOnSuccess.bind(this))
+    return this.Server.submitTransaction(transaction, {
+      networkPassphrase: new Network(
+        Config.get('modules.interstellar-network.networkPassphrase')
+      )
+    }).then(this._submitOnSuccess.bind(this))
       .catch(this._submitOnFailure.bind(this))
       .finally(this._submitFinally.bind(this));
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "interstellar-ui-messages": "~0.0.3",
     "lodash": "^4.17.13",
     "regenerator-runtime": "^0.13.3",
-    "stellar-sdk": "^2.0.1",
+    "stellar-sdk": "^5.0.0",
     "u2f-api": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bignumber.js": "^2.0.8",
     "interstellar": "https://github.com/stellar/interstellar.git#yarn",
     "interstellar-core": "~0.0.4",
-    "interstellar-network": "~0.0.12",
+    "interstellar-network": "./vendor/interstellar-network",
     "interstellar-sessions": "~0.0.10",
     "interstellar-ui-messages": "~0.0.3",
     "lodash": "^4.17.13",

--- a/templates/send-widget.template.html
+++ b/templates/send-widget.template.html
@@ -188,7 +188,7 @@ ng-class="widget.view == 'sendWaiting' ? 'sendPane--pending' : 'sendPane--idle'"
     </div>
 
     <button class="s-button sendOutcome__return" ng-if="widget.success || widget.result === 'failed'" ng-click="widget.showView($event, 'sendSetup')">Send another transaction</button>
-    <button class="s-button sendOutcome__return" ng-if="widget.result == 'requiredMemo'" ng-click="widget.showView($event, 'sendSetup')">Add a memo</button>
+    <button class="s-button sendOutcome__return" ng-if="!widget.success && widget.result == 'requiredMemo'" ng-click="widget.showView($event, 'sendSetup')">Add a memo</button>
   </div>
 
   <div class="additionalSigners" ng-if="widget.view === 'additionalSigners'">

--- a/templates/send-widget.template.html
+++ b/templates/send-widget.template.html
@@ -172,7 +172,7 @@ ng-class="widget.view == 'sendWaiting' ? 'sendPane--pending' : 'sendPane--idle'"
     <div ng-if="!widget.success">
       <p class="sendOutcome__label">Transaction failed</p>
 
-      <p class="" ng-if="widget.needsResubmit">
+      <p class="" ng-if="widget.result === 'needsResubmit'">
         <strong>Warning</strong> We submitted your transaction to the network but because of the network conditions we are
         not certain about it's status: it could either succeed or fail. Instead of recreating the transaction you should use
         the button below to safely resubmit the transaction:<br />
@@ -180,10 +180,15 @@ ng-class="widget.view == 'sendWaiting' ? 'sendPane--pending' : 'sendPane--idle'"
         <button class="s-button sendConfirm__submit" ng-click="widget.resubmitTransaction()">Resubmit transaction</button>
       </p>
 
+      <p class="" ng-if="widget.result === 'requiredMemo'">
+        This destination requires a memo. Forgotton memos can lead to delays in receiving your funds, or losing them altogether. Read <a href="https://medium.com/stellar-community/help-i-forgot-my-stellar-memo-d62b3cc9c2f7">our community page</a> on missing memos for more information.
+      </p>
+
       <pre class="sendOutcome__code" ng-if="widget.outcomeMessage"><code>{{widget.outcomeMessage}}</code></pre>
     </div>
 
-    <button class="s-button sendOutcome__return" ng-if="widget.success || !widget.needsResubmit" ng-click="widget.showView($event, 'sendSetup')">Send another transaction</button>
+    <button class="s-button sendOutcome__return" ng-if="widget.success || widget.result === 'failed'" ng-click="widget.showView($event, 'sendSetup')">Send another transaction</button>
+    <button class="s-button sendOutcome__return" ng-if="widget.result == 'requiredMemo'" ng-click="widget.showView($event, 'sendSetup')">Add a memo</button>
   </div>
 
   <div class="additionalSigners" ng-if="widget.view === 'additionalSigners'">

--- a/vendor/interstellar-network/index.es6
+++ b/vendor/interstellar-network/index.es6
@@ -1,0 +1,26 @@
+import {Module, Intent} from "interstellar-core";
+import interstellarSessions from "interstellar-sessions";
+
+import {Networks} from "stellar-sdk";
+export const NETWORK_PUBLIC  = Networks.PUBLIC;
+export const NETWORK_TESTNET = Networks.TESTNET;
+
+const mod = new Module('interstellar-network');
+export default mod;
+
+mod.services = require.context("./services", true);
+
+let addConfig = ConfigProvider => {
+  ConfigProvider.addModuleConfig(mod.name, {
+    networkPassphrase: NETWORK_TESTNET,
+    horizon: {
+      secure: true,
+      hostname: "horizon-testnet.stellar.org",
+      port: 443
+    }
+  });
+};
+addConfig.$inject = ['interstellar-core.ConfigProvider'];
+mod.config(addConfig);
+
+mod.define();

--- a/vendor/interstellar-network/package.json
+++ b/vendor/interstellar-network/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "interstellar-network",
+  "version": "0.0.12",
+  "description": "The interstellar-network module provides communication layer between Interstellar application and Stellar network.",
+  "keywords": [
+    "stellar",
+    "interstellar"
+  ],
+  "scripts": {
+    "test": "gulp test",
+    "postversion": "git push && git push --tags"
+  },
+  "author": "Stellar Development Foundation <stellar@stellar.org>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/stellar/interstellar-network.git"
+  },
+  "dependencies": {
+    "stellar-sdk": "~0.6.0",
+    "lodash": "^2.4.1",
+    "interstellar-core": "~0.0.3",
+    "bluebird": "^2.9.25"
+  }
+}

--- a/vendor/interstellar-network/package.json
+++ b/vendor/interstellar-network/package.json
@@ -17,7 +17,7 @@
     "url": "http://github.com/stellar/interstellar-network.git"
   },
   "dependencies": {
-    "stellar-sdk": "~0.6.0",
+    "stellar-sdk": "*",
     "lodash": "^2.4.1",
     "interstellar-core": "~0.0.3",
     "bluebird": "^2.9.25"

--- a/vendor/interstellar-network/services/account-observable.service.es6
+++ b/vendor/interstellar-network/services/account-observable.service.es6
@@ -1,0 +1,93 @@
+import {Inject, Service} from 'interstellar-core';
+import {contains, cloneDeep} from 'lodash';
+import Promise from 'bluebird';
+
+@Service('AccountObservable')
+@Inject('interstellar-network.Server')
+export default class AccountObservable {
+  constructor(Server) {
+    this.Server = Server;
+    this.streamingAddresses = [];
+    this.paymentListeners = {};
+    this.balanceChangeListeners = {};
+    this.balances = {};
+  }
+
+  _setupStreaming(address) {
+    if (!contains(this.streamingAddresses, address)) {
+      this.streamingAddresses.push(address);
+      this.paymentListeners[address] = [];
+      this.balanceChangeListeners[address] = [];
+
+      this.Server.payments()
+        .forAccount(address)
+        .stream({
+          onmessage: payment => this._onPayment.call(this, address, payment)
+        });
+    }
+  }
+
+  getPayments(address) {
+    return this.Server.payments()
+      .forAccount(address)
+      .order('desc')
+      .call()
+      .then(payments => {
+        return cloneDeep(payments);
+      });
+  }
+
+  getBalances(address) {
+    if (this.balances[address]) {
+      return Promise.resolve(cloneDeep(this.balances[address]));
+    } else {
+      return this._getBalances(address)
+        .then(balances => {
+          this.balances[address] = balances;
+          return cloneDeep(balances);
+        });
+    }
+  }
+
+  registerPaymentListener(address, listener) {
+    this._setupStreaming(address);
+    this.paymentListeners[address].push(listener);
+  }
+
+  registerBalanceChangeListener(address, listener) {
+    this._setupStreaming(address);
+    this.balanceChangeListeners[address].push(listener);
+  }
+
+  _getBalances(address) {
+    return this.Server.accounts()
+      .address(address)
+      .call()
+      .then(account => Promise.resolve(account.balances))
+      .catch(e => {
+        if (e.name === 'NotFoundError') {
+          return [];
+        } else {
+          throw e;
+        }
+      });
+  }
+
+  _onPayment(address, payment) {
+    if (this.paymentListeners[address]) {
+      for (var listener of this.paymentListeners[address]) {
+        listener(cloneDeep(payment));
+      }
+    }
+
+    if (this.balanceChangeListeners[address]) {
+      this._getBalances(address)
+        .then(balances => {
+          this.balances[address] = balances;
+          for (var listener of this.balanceChangeListeners[address]) {
+            listener(cloneDeep(balances));
+          }
+        });
+    }
+  }
+}

--- a/vendor/interstellar-network/services/server.service.es6
+++ b/vendor/interstellar-network/services/server.service.es6
@@ -1,0 +1,11 @@
+import {Inject, Service} from 'interstellar-core'
+import {Server as LibServer, Network} from 'stellar-sdk';
+
+@Service('Server')
+@Inject('interstellar-core.Config')
+export default class Server {
+  constructor(Config) {
+    Network.use(new Network(Config.get('modules.interstellar-network.networkPassphrase')));
+    return new LibServer(Config.get('modules.interstellar-network.horizon'));
+  }
+}

--- a/vendor/interstellar-network/services/server.service.es6
+++ b/vendor/interstellar-network/services/server.service.es6
@@ -1,11 +1,10 @@
 import {Inject, Service} from 'interstellar-core'
-import {Server as LibServer, Network} from 'stellar-sdk';
+import {Server as LibServer} from 'stellar-sdk';
 
 @Service('Server')
 @Inject('interstellar-core.Config')
 export default class Server {
   constructor(Config) {
-    Network.use(new Network(Config.get('modules.interstellar-network.networkPassphrase')));
     return new LibServer(Config.get('modules.interstellar-network.horizon'));
   }
 }

--- a/vendor/interstellar-network/test/network.connection.unit-test.es6
+++ b/vendor/interstellar-network/test/network.connection.unit-test.es6
@@ -1,0 +1,52 @@
+import { NetworkConnection } from "../lib/network-connection";
+
+describe("NetworkConnection", function() {
+  dontUseAngularQ();
+  
+  injectNg("stellard", {
+    network: "stellard.Network",
+    config: "core.Config",
+    q: "$q",
+  });
+
+  lazy("connectionSpec", function() {
+    return this.config.get("stellard/connections/live");
+  });
+
+  subject(function() {
+    return new NetworkConnection(this.q, this.network, "live", this.connectionSpec);
+  });
+
+  afterEach(function() {
+    this.subject.disconnect();
+  });
+
+  describe("#ensureConnected", function() {
+
+    context("when the remote websocket is successfully connected and the stellard returns an online status", function() {
+      setupMockSocket("online");
+
+      it("resolves the returns promise", function(done) {
+        this.subject.ensureConnected()
+          .then(nc => { done(); })
+          .catch(done)
+          ;
+      });
+
+    });
+
+    context("when the remote websocket closes immediately", function() {
+      setupMockSocket("immediate-close");
+      this.timeout(5000);
+
+      it("never resolves", function(done) {
+        // below is a crude race... if the subject resolved before 2 seconds pass.
+        // we fail
+        setTimeout(done, 2000);
+        this.subject.ensureConnected()
+          .then(nc => { done(new Error("did not expect resolve")); });
+      });
+    });
+
+  });
+});

--- a/vendor/interstellar-network/test/network.service.unit-test.es6
+++ b/vendor/interstellar-network/test/network.service.unit-test.es6
@@ -1,0 +1,9 @@
+import "../index";
+
+describe("stellard.Network", function() {
+  injectNg("stellard", {network: "stellard.Network"});
+
+  it("is not null", function() {
+    expect(this.network).to.be.an('object');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,6 +67,11 @@
   resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.5.tgz#f2083392f5859be59cbba0b1d463b922c8aef842"
   integrity sha512-LAyzQkr9rZDoHrv8xRcHStLo8Z4PbP3ZHMqw8WRr1T7Jn4O1z13Qkv+ed9e12pBXWaaqsBj1l4ADU/FlA/jn3w==
 
+"@types/urijs@^1.19.6":
+  version "1.19.8"
+  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.8.tgz#a66b2fd8b1d3cf3ef5bae7ca093b7d1b50e48c0a"
+  integrity sha512-SVQd2Qq0oL+b8VtJbQyv0cMIdU7fbRDcg2JIpcBvv+GUayJ3c5Ll1K+iivZl6ifcI6NbYcwjqDjljDFSiSGOeA==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -3578,14 +3583,13 @@ interstellar-core@~0.0.3, interstellar-core@~0.0.4:
     solar-css "git+https://github.com/stellar/solar#master"
     solar-stellarorg "git+https://github.com/stellar/solar-stellarorg#master"
 
-interstellar-network@~0.0.12:
+interstellar-network@./vendor/interstellar-network:
   version "0.0.12"
-  resolved "https://registry.yarnpkg.com/interstellar-network/-/interstellar-network-0.0.12.tgz#dd96aab5a2261642e351af3beb62ca9774f8e89b"
   dependencies:
     bluebird "^2.9.25"
     interstellar-core "~0.0.3"
     lodash "^2.4.1"
-    stellar-sdk "~0.6.0"
+    stellar-sdk "*"
 
 interstellar-sessions@~0.0.10:
   version "0.0.10"
@@ -4013,6 +4017,15 @@ js-xdr@^1.1.1:
   integrity sha512-zFg7dIc6lI7LiZ/eru5U/cOur/SJGkbKflgkwoFIiHewgpmBGsRJNKbeOh/8Ffzz5mYvfmsO6gHAe5wv/ZYM2g==
   dependencies:
     core-js "^2.6.3"
+    cursor "^0.1.5"
+    lodash "^4.17.5"
+    long "^2.2.3"
+
+js-xdr@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-1.1.4.tgz#678df4c6f8c7960de85bdf3bfa02b89df2730777"
+  integrity sha512-Xhwys9hyDZQDisxCKZi2nDhvGg6fKhsEgAUaJlzjwo32mZ2gZVIQl3+w4Le5SX5dsKDsboFdM2gnu5JALWetTg==
+  dependencies:
     cursor "^0.1.5"
     lodash "^4.17.5"
     long "^2.2.3"
@@ -6863,6 +6876,43 @@ stellar-base@^1.1.1:
     tweetnacl "^1.0.0"
   optionalDependencies:
     sodium-native "^2.3.0"
+
+stellar-base@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-3.0.0.tgz#ff1629ca8877b76267a4e4f7688b210f01a00a7f"
+  integrity sha512-81dzdEqoiqiW2kgzRAPaYoQDKZNFhGPMk+GDlksvs9jGfjgqW6ueawSwR5dGJEz8S5VFr3wiW33elQU48RjKFQ==
+  dependencies:
+    base32.js "^0.1.0"
+    bignumber.js "^4.0.0"
+    crc "^3.5.0"
+    js-xdr "^1.1.3"
+    lodash "^4.17.11"
+    sha.js "^2.3.6"
+    tweetnacl "^1.0.0"
+  optionalDependencies:
+    sodium-native "^2.3.0"
+
+stellar-sdk@*:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/stellar-sdk/-/stellar-sdk-5.0.0.tgz#c9cfd36ed9871142cc3ec9a9bbcd5efc834ec9c0"
+  integrity sha512-/D4OPnUnIXARkNwhnV9fFTBlDdulf/uAM/Gtb3l6T/0ERq8kiBbnI1GEKzlSNi1hWVAPulzpa9hw5NZWUdz4BQ==
+  dependencies:
+    "@types/eventsource" "^1.1.2"
+    "@types/node" ">= 8"
+    "@types/randombytes" "^2.0.0"
+    "@types/urijs" "^1.19.6"
+    axios "^0.19.0"
+    bignumber.js "^4.0.0"
+    detect-node "^2.0.4"
+    es6-promise "^4.2.4"
+    eventsource "^1.0.7"
+    lodash "^4.17.11"
+    randombytes "^2.1.0"
+    stellar-base "^3.0.0"
+    toml "^2.3.0"
+    tslib "^1.10.0"
+    urijs "^1.19.1"
+    utility-types "^3.7.0"
 
 stellar-sdk@^2.0.1:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,11 +62,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/urijs@^1.19.2":
-  version "1.19.5"
-  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.5.tgz#f2083392f5859be59cbba0b1d463b922c8aef842"
-  integrity sha512-LAyzQkr9rZDoHrv8xRcHStLo8Z4PbP3ZHMqw8WRr1T7Jn4O1z13Qkv+ed9e12pBXWaaqsBj1l4ADU/FlA/jn3w==
-
 "@types/urijs@^1.19.6":
   version "1.19.8"
   resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.8.tgz#a66b2fd8b1d3cf3ef5bae7ca093b7d1b50e48c0a"
@@ -1492,11 +1487,6 @@ core-js@^1.0.0:
 core-js@^2.4.0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
-
-core-js@^2.6.3:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
-  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -4007,16 +3997,6 @@ js-xdr@^1.0.0:
   resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-1.0.3.tgz#7ae0aba03969771a28dfe423ffc9e9d02d9301d7"
   dependencies:
     babel-runtime "^4.7.16"
-    cursor "^0.1.5"
-    lodash "^4.17.5"
-    long "^2.2.3"
-
-js-xdr@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-1.1.3.tgz#68cf021c0d8a6f8b75e8e3f2d528575a22d7cd1a"
-  integrity sha512-zFg7dIc6lI7LiZ/eru5U/cOur/SJGkbKflgkwoFIiHewgpmBGsRJNKbeOh/8Ffzz5mYvfmsO6gHAe5wv/ZYM2g==
-  dependencies:
-    core-js "^2.6.3"
     cursor "^0.1.5"
     lodash "^4.17.5"
     long "^2.2.3"
@@ -6862,21 +6842,6 @@ stellar-base@^0.6.0:
   optionalDependencies:
     ed25519 "0.0.4"
 
-stellar-base@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-1.1.2.tgz#7b08031f4a5cf4e95b8137472f367903a225ac3d"
-  integrity sha512-dBifZ2NPeOVtHl7pCaSCfvOedUGhKs3qIfqc/ajk9vsOFnHma0sBxb268kQhGWEAUS5tUKYei2ur4dQtB3rDSA==
-  dependencies:
-    base32.js "^0.1.0"
-    bignumber.js "^4.0.0"
-    crc "^3.5.0"
-    js-xdr "^1.1.1"
-    lodash "^4.17.11"
-    sha.js "^2.3.6"
-    tweetnacl "^1.0.0"
-  optionalDependencies:
-    sodium-native "^2.3.0"
-
 stellar-base@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-3.0.0.tgz#ff1629ca8877b76267a4e4f7688b210f01a00a7f"
@@ -6892,7 +6857,7 @@ stellar-base@^3.0.0:
   optionalDependencies:
     sodium-native "^2.3.0"
 
-stellar-sdk@*:
+stellar-sdk@*, stellar-sdk@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/stellar-sdk/-/stellar-sdk-5.0.0.tgz#c9cfd36ed9871142cc3ec9a9bbcd5efc834ec9c0"
   integrity sha512-/D4OPnUnIXARkNwhnV9fFTBlDdulf/uAM/Gtb3l6T/0ERq8kiBbnI1GEKzlSNi1hWVAPulzpa9hw5NZWUdz4BQ==
@@ -6909,28 +6874,6 @@ stellar-sdk@*:
     lodash "^4.17.11"
     randombytes "^2.1.0"
     stellar-base "^3.0.0"
-    toml "^2.3.0"
-    tslib "^1.10.0"
-    urijs "^1.19.1"
-    utility-types "^3.7.0"
-
-stellar-sdk@^2.0.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/stellar-sdk/-/stellar-sdk-2.3.0.tgz#f1c9005912c7c95d74e15fe1f7bd4f9c09841acd"
-  integrity sha512-iaeV8K98kuqgm1KH8dDitTp6qfpBb0XDZDnAVxCBCW9vs7AOnKadJbIKBtvVhuFXob4uRLvA3hfLJAAEjEzDcw==
-  dependencies:
-    "@types/eventsource" "^1.1.2"
-    "@types/node" ">= 8"
-    "@types/randombytes" "^2.0.0"
-    "@types/urijs" "^1.19.2"
-    axios "^0.19.0"
-    bignumber.js "^4.0.0"
-    detect-node "^2.0.4"
-    es6-promise "^4.2.4"
-    eventsource "^1.0.7"
-    lodash "^4.17.11"
-    randombytes "^2.1.0"
-    stellar-base "^1.1.1"
     toml "^2.3.0"
     tslib "^1.10.0"
     urijs "^1.19.1"


### PR DESCRIPTION
The Stellar SDK gets consumed via the `interstellar-network` package, which is deprecated and no longer maintained (by me). This PR overrides package.json to install it from local code, and edits the local code so that it uses the most recent SDK version.

Tested and confirmed this gets us SEP-29 (required memo) support but the error is a little ugly. I'll circle back before merging to get something a little prettier.

<img width="1128" alt="Screen Shot 2020-04-29 at 11 35 10 AM" src="https://user-images.githubusercontent.com/1551487/80615576-da4e6480-8a0d-11ea-9ab7-a837c3b66fd3.png">

`GAJVUHQV535IYW25XBTWTCUXNHLQN4F2PGIPOOX4DDKL2UPNXUHWU7B3` is the test address I was using (I own secret key) to test memo required behavior.